### PR TITLE
[BREAKING-CHANGE] [NCL-6230] store and share sizes of not built artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ information between runs in more detail.
 ### Checksums
 
 The `checksum-md5.json` file contains a map where the key is the MD5
-checksum of the file and the value is a list of all files with the
+checksum of the file and the value is a list of all files (and their sizes) with the
 checksum. Note that it is possible to have more than one file with the
 given checksum. For completeness, the `checksum-md5.json` file contains
 every single file found in the input, including any files found by

--- a/cli/src/main/java/org/jboss/pnc/build/finder/cli/Main.java
+++ b/cli/src/main/java/org/jboss/pnc/build/finder/cli/Main.java
@@ -61,6 +61,7 @@ import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.ConfigDefaults;
 import org.jboss.pnc.build.finder.core.DistributionAnalyzer;
 import org.jboss.pnc.build.finder.core.JSONUtils;
+import org.jboss.pnc.build.finder.core.LocalFile;
 import org.jboss.pnc.build.finder.core.Utils;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.jboss.pnc.build.finder.koji.KojiClientSession;
@@ -421,7 +422,8 @@ public final class Main implements Callable<Void> {
     }
 
     private void initCaches(BuildConfig config) {
-        KojiBuild.KojiBuildExternalizer externalizer = new KojiBuild.KojiBuildExternalizer();
+        KojiBuild.KojiBuildExternalizer kojiBuildExternalizer = new KojiBuild.KojiBuildExternalizer();
+        LocalFile.LocalFileExternalizer localFileExternalizer = new LocalFile.LocalFileExternalizer();
         GlobalConfigurationChildBuilder globalConfig = new GlobalConfigurationBuilder();
         String location = new File(ConfigDefaults.CONFIG_PATH, "cache").getAbsolutePath();
 
@@ -429,7 +431,8 @@ public final class Main implements Callable<Void> {
                 .persistentLocation(location)
                 .serialization()
                 .marshaller(new GenericJBossMarshaller())
-                .addAdvancedExternalizer(externalizer.getId(), externalizer)
+                .addAdvancedExternalizer(kojiBuildExternalizer.getId(), kojiBuildExternalizer)
+                .addAdvancedExternalizer(localFileExternalizer.getId(), localFileExternalizer)
                 .whiteList()
                 .addRegexp(".*")
                 .create();
@@ -543,7 +546,7 @@ public final class Main implements Callable<Void> {
                 "Checksum type: {}",
                 green(String.join(", ", checksumTypes.stream().map(String::valueOf).collect(Collectors.toSet()))));
 
-        Map<ChecksumType, MultiValuedMap<String, String>> checksumsFromFile = new EnumMap<>(ChecksumType.class);
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksumsFromFile = new EnumMap<>(ChecksumType.class);
 
         if (Boolean.TRUE.equals(config.getUseChecksumsFile())) {
             for (ChecksumType checksumType : checksumTypes) {
@@ -555,14 +558,14 @@ public final class Main implements Callable<Void> {
                     LOGGER.info("Loading checksums from file: {}", green(checksumFile));
 
                     try {
-                        Map<String, Collection<String>> subChecksums = JSONUtils.loadChecksumsFile(checksumFile);
-                        Set<Entry<String, Collection<String>>> entrySet = subChecksums.entrySet();
+                        Map<String, Collection<LocalFile>> subChecksums = JSONUtils.loadChecksumsFile(checksumFile);
+                        Set<Entry<String, Collection<LocalFile>>> entrySet = subChecksums.entrySet();
 
-                        for (Entry<String, Collection<String>> entry : entrySet) {
+                        for (Entry<String, Collection<LocalFile>> entry : entrySet) {
                             String key = entry.getKey();
-                            Collection<String> values = entry.getValue();
+                            Collection<LocalFile> values = entry.getValue();
 
-                            for (String value : values) {
+                            for (LocalFile value : values) {
                                 checksumsFromFile.get(checksumType).put(key, value);
                             }
                         }
@@ -578,7 +581,7 @@ public final class Main implements Callable<Void> {
             }
         }
 
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = checksumsFromFile;
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = checksumsFromFile;
 
         if (Boolean.TRUE.equals(checksumOnly)) {
             if (Boolean.FALSE.equals(config.getUseChecksumsFile())) {
@@ -589,7 +592,7 @@ public final class Main implements Callable<Void> {
                 pool = Executors.newSingleThreadExecutor();
 
                 DistributionAnalyzer analyzer = new DistributionAnalyzer(files, config, cacheManager);
-                Future<Map<ChecksumType, MultiValuedMap<String, String>>> futureChecksum = pool.submit(analyzer);
+                Future<Map<ChecksumType, MultiValuedMap<String, LocalFile>>> futureChecksum = pool.submit(analyzer);
 
                 try {
                     checksums = futureChecksum.get();
@@ -690,11 +693,16 @@ public final class Main implements Callable<Void> {
                     Map<Checksum, Collection<String>> newMap = new HashMap<>();
 
                     for (ChecksumType checksumType : checksumTypes) {
-                        Map<String, Collection<String>> map = checksums.get(checksumType).asMap();
+                        Map<String, Collection<LocalFile>> map = checksums.get(checksumType).asMap();
 
-                        for (Entry<String, Collection<String>> entry : map.entrySet()) {
-                            for (String filename : entry.getValue()) {
-                                newMap.put(new Checksum(checksumType, entry.getKey(), filename), entry.getValue());
+                        for (Entry<String, Collection<LocalFile>> entry : map.entrySet()) {
+                            for (LocalFile filename : entry.getValue()) {
+                                newMap.put(
+                                        new Checksum(checksumType, entry.getKey(), filename),
+                                        entry.getValue()
+                                                .stream()
+                                                .map(LocalFile::getFilename)
+                                                .collect(Collectors.toList()));
                             }
                         }
                     }
@@ -715,7 +723,7 @@ public final class Main implements Callable<Void> {
                 pool = Executors.newFixedThreadPool(2);
 
                 DistributionAnalyzer analyzer = new DistributionAnalyzer(files, config, cacheManager);
-                Future<Map<ChecksumType, MultiValuedMap<String, String>>> futureChecksum = pool.submit(analyzer);
+                Future<Map<ChecksumType, MultiValuedMap<String, LocalFile>>> futureChecksum = pool.submit(analyzer);
 
                 boolean isKerberos = krbService != null && krbPrincipal != null && krbPassword != null
                         || krbCCache != null || krbKeytab != null;

--- a/cli/src/main/java/org/jboss/pnc/build/finder/cli/Main.java
+++ b/cli/src/main/java/org/jboss/pnc/build/finder/cli/Main.java
@@ -425,7 +425,7 @@ public final class Main implements Callable<Void> {
         KojiBuild.KojiBuildExternalizer kojiBuildExternalizer = new KojiBuild.KojiBuildExternalizer();
         LocalFile.LocalFileExternalizer localFileExternalizer = new LocalFile.LocalFileExternalizer();
         GlobalConfigurationChildBuilder globalConfig = new GlobalConfigurationBuilder();
-        String location = new File(ConfigDefaults.CONFIG_PATH, "cache").getAbsolutePath();
+        String location = new File(ConfigDefaults.CACHE_LOCATION).getAbsolutePath();
 
         globalConfig.globalState()
                 .persistentLocation(location)

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/BuildFinderUtils.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/BuildFinderUtils.java
@@ -185,6 +185,7 @@ public final class BuildFinderUtils {
             tmpArchive.setBuildId(0);
             tmpArchive.setFilename("not found");
             tmpArchive.setChecksum(checksum.getValue());
+            tmpArchive.setSize((int) checksum.getFileSize());
             tmpArchive.setChecksumType(KojiChecksumType.valueOf(checksum.getType().name()));
 
             tmpArchive.setArchiveId(-1 * (buildZero.getArchives().size() + 1));

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/Checksum.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/Checksum.java
@@ -63,14 +63,24 @@ public class Checksum implements Serializable {
     @JsonIgnore
     private String filename;
 
+    private long fileSize;
+
     public Checksum() {
 
     }
 
-    public Checksum(ChecksumType type, String value, String filename) {
+    public Checksum(ChecksumType type, String value, String filename, long fileSize) {
         this.type = type;
         this.value = value;
         this.filename = filename;
+        this.fileSize = fileSize;
+    }
+
+    public Checksum(ChecksumType type, String value, LocalFile localFile) {
+        this.type = type;
+        this.value = value;
+        this.filename = localFile.getFilename();
+        this.fileSize = localFile.getSize();
     }
 
     public static Set<Checksum> checksum(FileObject fo, Collection<ChecksumType> checksumTypes, String root)
@@ -89,6 +99,7 @@ public class Checksum implements Serializable {
         Collection<CompletableFuture<Void>> futures = new ArrayList<>(checksumTypesSize);
         Map<ChecksumType, CompletableFuture<Checksum>> futures2 = new EnumMap<>(ChecksumType.class);
         FileName filename = fo.getName();
+        long fileSize = fo.getContent().getSize();
 
         if ("rpm".equals(filename.getExtension())) {
             try (FileContent fc = fo.getContent();
@@ -127,7 +138,7 @@ public class Checksum implements Serializable {
                             String sigmd5 = Hex.encodeHexString((byte[]) md5);
 
                             future = CompletableFuture.supplyAsync(
-                                    () -> new Checksum(checksumType, sigmd5, Utils.normalizePath(fo, root)));
+                                    () -> new Checksum(checksumType, sigmd5, Utils.normalizePath(fo, root), fileSize));
 
                             futures2.put(checksumType, future);
                             break;
@@ -142,7 +153,7 @@ public class Checksum implements Serializable {
                             String sigsha1 = Hex.encodeHexString((byte[]) sha1);
 
                             future = CompletableFuture.supplyAsync(
-                                    () -> new Checksum(checksumType, sigsha1, Utils.normalizePath(fo, root)));
+                                    () -> new Checksum(checksumType, sigsha1, Utils.normalizePath(fo, root), fileSize));
 
                             futures2.put(checksumType, future);
                             break;
@@ -157,7 +168,11 @@ public class Checksum implements Serializable {
                             String sigsha256 = Hex.encodeHexString((byte[]) sha256);
 
                             future = CompletableFuture.supplyAsync(
-                                    () -> new Checksum(checksumType, sigsha256, Utils.normalizePath(fo, root)));
+                                    () -> new Checksum(
+                                            checksumType,
+                                            sigsha256,
+                                            Utils.normalizePath(fo, root),
+                                            fileSize));
 
                             futures2.put(checksumType, future);
                             break;
@@ -195,7 +210,11 @@ public class Checksum implements Serializable {
             for (ChecksumType checksumType : checksumTypes) {
                 CompletableFuture<Checksum> future = CompletableFuture.supplyAsync(() -> {
                     MessageDigest md = mds.get(checksumType);
-                    return new Checksum(checksumType, Hex.encodeHexString(md.digest()), Utils.normalizePath(fo, root));
+                    return new Checksum(
+                            checksumType,
+                            Hex.encodeHexString(md.digest()),
+                            Utils.normalizePath(fo, root),
+                            fileSize);
                 });
 
                 futures2.put(checksumType, future);
@@ -256,6 +275,14 @@ public class Checksum implements Serializable {
 
     public void setFilename(String filename) {
         this.filename = filename;
+    }
+
+    public long getFileSize() {
+        return fileSize;
+    }
+
+    public void setFileSize(long fileSize) {
+        this.fileSize = fileSize;
     }
 
     @Override

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/Checksum.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/Checksum.java
@@ -288,6 +288,6 @@ public class Checksum implements Serializable {
     @Override
     public String toString() {
         return "Checksum{" + "type=" + type + ", value='" + value + '\'' + ", filename='" + filename + '\''
-                + ", fileSize='" + fileSize + '\'' + '}';
+                + ", fileSize=" + fileSize + '}';
     }
 }

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/Checksum.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/Checksum.java
@@ -287,6 +287,7 @@ public class Checksum implements Serializable {
 
     @Override
     public String toString() {
-        return "Checksum{" + "type=" + type + ", value='" + value + '\'' + ", filename='" + filename + '\'' + '}';
+        return "Checksum{" + "type=" + type + ", value='" + value + '\'' + ", filename='" + filename + '\''
+                + ", fileSize='" + fileSize + '\'' + '}';
     }
 }

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/ConfigDefaults.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/ConfigDefaults.java
@@ -56,6 +56,7 @@ public abstract class ConfigDefaults {
     public static final String CONFIG_PATH = USER_HOME + File.separator + ".build-finder";
     public static final String CONFIG = CONFIG_PATH + File.separator + CONFIG_FILE;
     public static final Boolean DISABLE_CACHE = Boolean.FALSE;
+    public static final String CACHE_LOCATION = CONFIG_PATH + File.separator + "cache";
     public static final Boolean DISABLE_RECURSION = Boolean.FALSE;
     public static final List<Pattern> EXCLUDES = Collections
             .singletonList(Pattern.compile("^(?!.*/pom\\.xml$).*/.*\\.xml$"));

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/DistributionAnalyzer.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/DistributionAnalyzer.java
@@ -221,7 +221,7 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
                                     LOGGER.error(
                                             "Error loading cache {}: {}. The cache format has changed"
                                                     + " and you will have to manually delete the existing cache",
-                                            boldRed(getCacheLocation()),
+                                            boldRed(ConfigDefaults.CACHE_LOCATION),
                                             boldRed(e.getMessage()),
                                             e);
                                     throw e;
@@ -326,10 +326,6 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
         }
 
         return Collections.unmodifiableMap(map);
-    }
-
-    private String getCacheLocation() {
-        return new File(ConfigDefaults.CONFIG_PATH, "cache").getAbsolutePath();
     }
 
     private boolean isArchive(FileObject fo) {

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/DistributionAnalyzer.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/DistributionAnalyzer.java
@@ -219,7 +219,8 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
                                     }
                                 } catch (ClassCastException e) {
                                     LOGGER.error(
-                                            "Error loading cache {}: {}. The cache format has changed and you will have to manually delete the existing cache",
+                                            "Error loading cache {}: {}. The cache format has changed"
+                                                    + " and you will have to manually delete the existing cache",
                                             boldRed(getCacheLocation()),
                                             boldRed(e.getMessage()),
                                             e);

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/DistributionAnalyzer.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/DistributionAnalyzer.java
@@ -60,7 +60,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiValuedMap<String, String>>> {
+public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiValuedMap<String, LocalFile>>> {
     private static final Logger LOGGER = LoggerFactory.getLogger(DistributionAnalyzer.class);
 
     /**
@@ -80,7 +80,7 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
 
     private final BuildConfig config;
 
-    private final Map<ChecksumType, Cache<String, MultiValuedMap<String, String>>> fileCaches;
+    private final Map<ChecksumType, Cache<String, MultiValuedMap<String, LocalFile>>> fileCaches;
 
     private final EmbeddedCacheManager cacheManager;
 
@@ -92,7 +92,7 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
 
     private final List<FileError> fileErrors;
 
-    private Map<ChecksumType, MultiValuedMap<String, String>> map;
+    private Map<ChecksumType, MultiValuedMap<String, LocalFile>> map;
 
     private StandardFileSystemManager sfs;
 
@@ -141,7 +141,7 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
         return exts.contains(ext);
     }
 
-    public Map<ChecksumType, MultiValuedMap<String, String>> checksumFiles() throws IOException {
+    public Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksumFiles() throws IOException {
         Instant startTime = Instant.now();
         FileObject fo = null;
         sfs = new StandardFileSystemManager();
@@ -204,21 +204,21 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
                                 .orElse(null);
 
                         if (value != null) {
-                            MultiValuedMap<String, String> localMap = fileCaches.get(checksumType).get(value);
+                            MultiValuedMap<String, LocalFile> localMap = fileCaches.get(checksumType).get(value);
 
                             if (localMap != null) {
                                 this.map.get(checksumType).putAll(localMap);
 
-                                Collection<Map.Entry<String, String>> entries = localMap.entries();
+                                Collection<Map.Entry<String, LocalFile>> entries = localMap.entries();
 
-                                for (Map.Entry<String, String> entry : entries) {
+                                for (Map.Entry<String, LocalFile> entry : entries) {
                                     inverseMap.put(
-                                            entry.getValue(),
+                                            entry.getValue().getFilename(),
                                             new Checksum(checksumType, entry.getKey(), entry.getValue()));
                                 }
 
                                 if (queue != null && checksumType == ChecksumType.md5) {
-                                    for (Map.Entry<String, String> entry : entries) {
+                                    for (Map.Entry<String, LocalFile> entry : entries) {
                                         try {
                                             Checksum checksum = new Checksum(
                                                     checksumType,
@@ -414,7 +414,8 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
 
                 if (optionalChecksum.isPresent()) {
                     Checksum checksum = optionalChecksum.get();
-                    map.get(checksumType).put(checksum.getValue(), checksum.getFilename());
+                    map.get(checksumType)
+                            .put(checksum.getValue(), new LocalFile(checksum.getFilename(), checksum.getFileSize()));
                 }
             }
 
@@ -513,11 +514,11 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
         return Collections.unmodifiableMap(inverseMap.asMap());
     }
 
-    public void setChecksums(Map<ChecksumType, MultiValuedMap<String, String>> map) {
+    public void setChecksums(Map<ChecksumType, MultiValuedMap<String, LocalFile>> map) {
         this.map = map;
     }
 
-    public Map<String, Collection<String>> getChecksums(ChecksumType checksumType) {
+    public Map<String, Collection<LocalFile>> getChecksums(ChecksumType checksumType) {
         return Collections.unmodifiableMap(map.get(checksumType).asMap());
     }
 
@@ -525,12 +526,12 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
         return Collections.unmodifiableList(fileErrors);
     }
 
-    public Map<ChecksumType, MultiValuedMap<String, String>> getChecksums() {
+    public Map<ChecksumType, MultiValuedMap<String, LocalFile>> getChecksums() {
         return Collections.unmodifiableMap(map);
     }
 
     @Override
-    public Map<ChecksumType, MultiValuedMap<String, String>> call() throws IOException {
+    public Map<ChecksumType, MultiValuedMap<String, LocalFile>> call() throws IOException {
         queue = new LinkedBlockingQueue<>();
 
         checksumFiles();

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/JSONUtils.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/JSONUtils.java
@@ -47,13 +47,12 @@ public final class JSONUtils {
         FileUtils.writeLines(file, Collections.singletonList(null), true);
     }
 
-    public static Map<String, Collection<String>> loadChecksumsFile(File file) throws IOException {
-        TypeReference<Map<String, Collection<String>>> typeReference = new MapTypeReference();
-
+    public static Map<String, Collection<LocalFile>> loadChecksumsFile(File file) throws IOException {
+        TypeReference<Map<String, Collection<LocalFile>>> typeReference = new MapTypeReference();
         return MAPPER.readValue(file, typeReference);
     }
 
-    private static class MapTypeReference extends TypeReference<Map<String, Collection<String>>> {
+    private static class MapTypeReference extends TypeReference<Map<String, Collection<LocalFile>>> {
         MapTypeReference() {
 
         }

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/LocalFile.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/LocalFile.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.pnc.build.finder.core;
 
 import java.io.IOException;
@@ -34,7 +49,13 @@ public class LocalFile {
         return size;
     }
 
+    @Override
+    public String toString() {
+        return "LocalFile{" + "filename='" + filename + '\'' + ", size=" + size + '}';
+    }
+
     public static class LocalFileExternalizer implements AdvancedExternalizer<LocalFile> {
+        private static final long serialVersionUID = -3322870654564600039L;
 
         private static final Integer ID = (Character.getNumericValue('L') << 16) | (Character.getNumericValue('F') << 8)
                 | Character.getNumericValue('E');

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/LocalFile.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/LocalFile.java
@@ -1,0 +1,75 @@
+package org.jboss.pnc.build.finder.core;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Set;
+
+import org.infinispan.commons.marshall.AdvancedExternalizer;
+import org.infinispan.commons.marshall.SerializeWith;
+import org.infinispan.commons.util.Util;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize
+@SerializeWith(LocalFile.LocalFileExternalizer.class)
+public class LocalFile {
+    private final String filename;
+
+    private final long size;
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public LocalFile(@JsonProperty("filename") String filename, @JsonProperty("size") long size) {
+        this.filename = filename;
+        this.size = size;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public static class LocalFileExternalizer implements AdvancedExternalizer<LocalFile> {
+
+        private static final Integer ID = (Character.getNumericValue('L') << 16) | (Character.getNumericValue('F') << 8)
+                | Character.getNumericValue('E');
+
+        private static final int VERSION = 1;
+
+        @Override
+        public void writeObject(ObjectOutput output, LocalFile object) throws IOException {
+            output.writeInt(VERSION);
+            output.writeObject(object.getFilename());
+            output.writeLong(object.getSize());
+        }
+
+        @Override
+        public LocalFile readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+            int version = input.readInt();
+
+            if (version != 1) {
+                throw new IOException("Invalid version: " + version);
+            }
+
+            String filename = (String) input.readObject();
+            long size = input.readLong();
+
+            return new LocalFile(filename, size);
+        }
+
+        @Override
+        public Set<Class<? extends LocalFile>> getTypeClasses() {
+            return Util.asSet(LocalFile.class);
+        }
+
+        @Override
+        public Integer getId() {
+            return ID;
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/LocalFile.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/LocalFile.java
@@ -65,7 +65,7 @@ public class LocalFile {
         @Override
         public void writeObject(ObjectOutput output, LocalFile object) throws IOException {
             output.writeInt(VERSION);
-            output.writeObject(object.getFilename());
+            output.writeUTF(object.getFilename());
             output.writeLong(object.getSize());
         }
 
@@ -73,11 +73,11 @@ public class LocalFile {
         public LocalFile readObject(ObjectInput input) throws IOException, ClassNotFoundException {
             int version = input.readInt();
 
-            if (version != 1) {
+            if (version != VERSION) {
                 throw new IOException("Invalid version: " + version);
             }
 
-            String filename = (String) input.readObject();
+            String filename = input.readUTF();
             long size = input.readLong();
 
             return new LocalFile(filename, size);

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/BuildFinderTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/BuildFinderTest.java
@@ -74,7 +74,7 @@ class BuildFinderTest {
         da.checksumFiles();
         da.outputToFile(checksumType);
 
-        Map<String, Collection<String>> checksums = JSONUtils.loadChecksumsFile(da.getChecksumFile(checksumType));
+        Map<String, Collection<LocalFile>> checksums = JSONUtils.loadChecksumsFile(da.getChecksumFile(checksumType));
 
         assertThat(checksums, is(aMapWithSize(1)));
     }

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/CompletedBuildTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/CompletedBuildTest.java
@@ -51,11 +51,13 @@ class CompletedBuildTest {
         Checksum checksum1 = new Checksum(
                 ChecksumType.md5,
                 "46148535be98c75c900837ecea491c71",
-                "hibernate-validator-6.0.10.Final-redhat-1.pom");
+                "hibernate-validator-6.0.10.Final-redhat-1.pom",
+                10L);
         Checksum checksum2 = new Checksum(
                 ChecksumType.md5,
                 "c723630b4a215ffa05106e5c8555871c",
-                "hibernate-validator-cdi-6.0.10.Final-redhat-1.pom");
+                "hibernate-validator-cdi-6.0.10.Final-redhat-1.pom",
+                10L);
         Collection<String> filenames1 = Collections.singletonList("hibernate-validator-6.0.10.Final-redhat-1.pom");
         Collection<String> filenames2 = Collections.singletonList("hibernate-validator-cdi-6.0.10.Final-redhat-1.pom");
         Map<Checksum, Collection<String>> checksumTable = new LinkedHashMap<>(2, 1.0f);

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/CompletedBuildTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/CompletedBuildTest.java
@@ -52,12 +52,12 @@ class CompletedBuildTest {
                 ChecksumType.md5,
                 "46148535be98c75c900837ecea491c71",
                 "hibernate-validator-6.0.10.Final-redhat-1.pom",
-                10L);
+                19544L);
         Checksum checksum2 = new Checksum(
                 ChecksumType.md5,
                 "c723630b4a215ffa05106e5c8555871c",
                 "hibernate-validator-cdi-6.0.10.Final-redhat-1.pom",
-                10L);
+                8591L);
         Collection<String> filenames1 = Collections.singletonList("hibernate-validator-6.0.10.Final-redhat-1.pom");
         Collection<String> filenames2 = Collections.singletonList("hibernate-validator-cdi-6.0.10.Final-redhat-1.pom");
         Map<Checksum, Collection<String>> checksumTable = new LinkedHashMap<>(2, 1.0f);

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/DeletedAndCompletedBuildTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/DeletedAndCompletedBuildTest.java
@@ -52,12 +52,12 @@ class DeletedAndCompletedBuildTest {
                 ChecksumType.md5,
                 "59ef4fa1ef35fc0fc074dbfab196c0cd",
                 "wildfly-core-security-7.5.9.Final-redhat-2.jar",
-                10L);
+                22827L);
         Checksum checksum2 = new Checksum(
                 ChecksumType.md5,
                 "36f95ca365830463f581d576eb2f1f84",
                 "wildfly-core-security-7.5.9.Final-redhat-2.pom",
-                10L);
+                3105L);
         Collection<String> filenames1 = Collections.singletonList("wildfly-core-security-7.5.9.Final-redhat-2.jar");
         Collection<String> filenames2 = Collections.singletonList("wildfly-core-security-7.5.9.Final-redhat-2.pom");
         Map<Checksum, Collection<String>> checksumTable = new LinkedHashMap<>(2, 1.0f);

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/DeletedAndCompletedBuildTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/DeletedAndCompletedBuildTest.java
@@ -51,11 +51,13 @@ class DeletedAndCompletedBuildTest {
         Checksum checksum1 = new Checksum(
                 ChecksumType.md5,
                 "59ef4fa1ef35fc0fc074dbfab196c0cd",
-                "wildfly-core-security-7.5.9.Final-redhat-2.jar");
+                "wildfly-core-security-7.5.9.Final-redhat-2.jar",
+                10L);
         Checksum checksum2 = new Checksum(
                 ChecksumType.md5,
                 "36f95ca365830463f581d576eb2f1f84",
-                "wildfly-core-security-7.5.9.Final-redhat-2.pom");
+                "wildfly-core-security-7.5.9.Final-redhat-2.pom",
+                10L);
         Collection<String> filenames1 = Collections.singletonList("wildfly-core-security-7.5.9.Final-redhat-2.jar");
         Collection<String> filenames2 = Collections.singletonList("wildfly-core-security-7.5.9.Final-redhat-2.pom");
         Map<Checksum, Collection<String>> checksumTable = new LinkedHashMap<>(2, 1.0f);

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/DeletedBuildTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/DeletedBuildTest.java
@@ -52,7 +52,7 @@ class DeletedBuildTest {
                 ChecksumType.md5,
                 "a8c05c0ff2b61c3e205fb21010581bbe",
                 "infinispan-bom-9.4.16.Final-redhat-00001.pom",
-                10L);
+                23476L);
         Collection<String> filenames = Collections.singletonList("wildfly-core-security-7.5.9.Final-redhat-2.jar");
         Map<Checksum, Collection<String>> checksumTable = new LinkedHashMap<>(2, 1.0f);
 

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/DeletedBuildTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/DeletedBuildTest.java
@@ -51,7 +51,8 @@ class DeletedBuildTest {
         Checksum checksum = new Checksum(
                 ChecksumType.md5,
                 "a8c05c0ff2b61c3e205fb21010581bbe",
-                "infinispan-bom-9.4.16.Final-redhat-00001.pom");
+                "infinispan-bom-9.4.16.Final-redhat-00001.pom",
+                10L);
         Collection<String> filenames = Collections.singletonList("wildfly-core-security-7.5.9.Final-redhat-2.jar");
         Map<Checksum, Collection<String>> checksumTable = new LinkedHashMap<>(2, 1.0f);
 

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/DistributionAnalyzerTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/DistributionAnalyzerTest.java
@@ -60,7 +60,7 @@ class DistributionAnalyzerTest {
         BuildConfig config = new BuildConfig();
         config.setArchiveExtensions(Collections.emptyList());
         DistributionAnalyzer da = new DistributionAnalyzer(af, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> map = da.checksumFiles();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> map = da.checksumFiles();
         map.forEach((key, value) -> assertThat(value.asMap(), is((anEmptyMap()))));
     }
 
@@ -77,7 +77,7 @@ class DistributionAnalyzerTest {
             BuildConfig config = new BuildConfig();
             config.setArchiveExtensions(Collections.emptyList());
             DistributionAnalyzer da = new DistributionAnalyzer(af, config);
-            Map<ChecksumType, MultiValuedMap<String, String>> map = da.checksumFiles();
+            Map<ChecksumType, MultiValuedMap<String, LocalFile>> map = da.checksumFiles();
             map.forEach((key, value) -> assertThat(value.asMap().values(), hasSize(1)));
         }
     }
@@ -96,7 +96,7 @@ class DistributionAnalyzerTest {
         BuildConfig config = new BuildConfig();
         config.setArchiveExtensions(Collections.emptyList());
         DistributionAnalyzer da = new DistributionAnalyzer(af, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> map = da.checksumFiles();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> map = da.checksumFiles();
         map.forEach((key, value) -> assertThat(value.asMap(), is((aMapWithSize(1)))));
     }
 
@@ -123,7 +123,7 @@ class DistributionAnalyzerTest {
         BuildConfig config = new BuildConfig();
         config.setArchiveExtensions(Collections.emptyList());
         DistributionAnalyzer da = new DistributionAnalyzer(target, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = da.checksumFiles();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = da.checksumFiles();
 
         assertThat(checksums.get(ChecksumType.md5).size(), is(25));
     }
@@ -134,7 +134,7 @@ class DistributionAnalyzerTest {
         BuildConfig config = new BuildConfig();
         config.setArchiveExtensions(Collections.emptyList());
         DistributionAnalyzer da = new DistributionAnalyzer(target, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = da.checksumFiles();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = da.checksumFiles();
 
         assertThat(checksums.get(ChecksumType.md5).size(), is(7));
     }
@@ -146,7 +146,7 @@ class DistributionAnalyzerTest {
         BuildConfig config = new BuildConfig();
         config.setArchiveExtensions(Collections.emptyList());
         DistributionAnalyzer da = new DistributionAnalyzer(target, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = da.checksumFiles();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = da.checksumFiles();
 
         assertThat(checksums.get(ChecksumType.md5).size(), is(4));
         assertThat(out.capturedLines(), hasItemInArray(containsString("Unable to process archive/compressed file")));
@@ -158,7 +158,7 @@ class DistributionAnalyzerTest {
         BuildConfig config = new BuildConfig();
         config.setArchiveExtensions(Collections.emptyList());
         DistributionAnalyzer da = new DistributionAnalyzer(target, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = da.call();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = da.call();
 
         assertThat(checksums.get(ChecksumType.md5).size(), is(25));
     }
@@ -173,7 +173,7 @@ class DistributionAnalyzerTest {
         assertThat(config.getChecksumTypes(), hasSize(3));
 
         DistributionAnalyzer da = new DistributionAnalyzer(target, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = da.call();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = da.call();
 
         assertThat(checksums.keySet().size(), is(config.getChecksumTypes().size()));
 
@@ -186,9 +186,9 @@ class DistributionAnalyzerTest {
         for (ChecksumType checksumType : checksumTypes) {
             assertThat(checksums.get(checksumType).size(), is(25));
 
-            for (Entry<String, String> entry : checksums.get(checksumType).entries()) {
+            for (Entry<String, LocalFile> entry : checksums.get(checksumType).entries()) {
                 String checksum = entry.getKey();
-                String filename = entry.getValue();
+                String filename = entry.getValue().getFilename();
                 Collection<Checksum> fileChecksums = da.getFiles().get(filename);
                 Optional<Checksum> cksum = Checksum.findByType(fileChecksums, checksumType);
 
@@ -216,7 +216,7 @@ class DistributionAnalyzerTest {
         config.setArchiveExtensions(Collections.emptyList());
         config.setDisableRecursion(true);
         DistributionAnalyzer da = new DistributionAnalyzer(target, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = da.checksumFiles();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = da.checksumFiles();
 
         assertThat(checksums.get(ChecksumType.md5).size(), is(3));
     }
@@ -228,7 +228,7 @@ class DistributionAnalyzerTest {
         config.setArchiveExtensions(Collections.emptyList());
         config.setDisableRecursion(true);
         DistributionAnalyzer da = new DistributionAnalyzer(target, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = da.checksumFiles();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = da.checksumFiles();
 
         assertThat(checksums.get(ChecksumType.md5).size(), is(2));
     }
@@ -240,7 +240,7 @@ class DistributionAnalyzerTest {
         config.setArchiveExtensions(Collections.emptyList());
         config.setDisableRecursion(true);
         DistributionAnalyzer da = new DistributionAnalyzer(target, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = da.checksumFiles();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = da.checksumFiles();
 
         assertThat(checksums.get(ChecksumType.md5).size(), is(1));
     }
@@ -252,7 +252,7 @@ class DistributionAnalyzerTest {
         config.setArchiveExtensions(Collections.emptyList());
         config.setDisableRecursion(true);
         DistributionAnalyzer da = new DistributionAnalyzer(target, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = da.checksumFiles();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = da.checksumFiles();
 
         assertThat(checksums.get(ChecksumType.md5).size(), is(4));
     }

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/EmptyBuildsTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/EmptyBuildsTest.java
@@ -71,8 +71,8 @@ class EmptyBuildsTest {
                 ChecksumType.md5,
                 "ca5330166ccd4e2b205bed4b88f924b0",
                 "random.jar!random.jar",
-                10L);
-        Checksum checksum2 = new Checksum(ChecksumType.md5, "b3ba80c13aa555c3eb428dbf62e2c48e", "random.jar", 10L);
+                -1L);
+        Checksum checksum2 = new Checksum(ChecksumType.md5, "b3ba80c13aa555c3eb428dbf62e2c48e", "random.jar", -1L);
         Collection<String> filenames1 = Collections.singletonList("random.jar!random.jar");
         Collection<String> filenames2 = Collections.singletonList("random.jar");
         Map<Checksum, Collection<String>> checksumTable = new LinkedHashMap<>(2, 1.0f);

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/EmptyBuildsTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/EmptyBuildsTest.java
@@ -70,8 +70,9 @@ class EmptyBuildsTest {
         Checksum checksum1 = new Checksum(
                 ChecksumType.md5,
                 "ca5330166ccd4e2b205bed4b88f924b0",
-                "random.jar!random.jar");
-        Checksum checksum2 = new Checksum(ChecksumType.md5, "b3ba80c13aa555c3eb428dbf62e2c48e", "random.jar");
+                "random.jar!random.jar",
+                10L);
+        Checksum checksum2 = new Checksum(ChecksumType.md5, "b3ba80c13aa555c3eb428dbf62e2c48e", "random.jar", 10L);
         Collection<String> filenames1 = Collections.singletonList("random.jar!random.jar");
         Collection<String> filenames2 = Collections.singletonList("random.jar");
         Map<Checksum, Collection<String>> checksumTable = new LinkedHashMap<>(2, 1.0f);

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/FileObjectTrackingTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/FileObjectTrackingTest.java
@@ -96,7 +96,7 @@ class FileObjectTrackingTest {
         config.setArchiveExtensions(Collections.emptyList());
 
         DistributionAnalyzer da = new DistributionAnalyzer(target, config);
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = da.checksumFiles();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = da.checksumFiles();
 
         assertThat(checksums.get(ChecksumType.md5).size(), is(25));
 

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/PncBuildFinderTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/PncBuildFinderTest.java
@@ -88,7 +88,7 @@ class PncBuildFinderTest {
     void shouldFindOneBuildInPnc() throws RemoteResourceException {
         // given
         String md5 = "md5-checksum";
-        String filename = "empty.jar";
+        LocalFile filename = new LocalFile("empty.jar", 10L);
         Checksum checksum = new Checksum(ChecksumType.md5, md5, filename);
         PncClient pncClient = Mockito.mock(PncClient.class);
         String buildId = "100";
@@ -115,8 +115,8 @@ class PncBuildFinderTest {
                 .id("100")
                 .identifier("org.empty:empty")
                 .md5(md5)
-                .size(10L)
-                .filename(filename)
+                .size(filename.getSize())
+                .filename(filename.getFilename())
                 .build(build)
                 .build();
 
@@ -129,7 +129,7 @@ class PncBuildFinderTest {
 
         // when
         Map<Checksum, Collection<String>> requestMap = Collections
-                .singletonMap(checksum, Collections.singletonList(filename));
+                .singletonMap(checksum, Collections.singletonList(filename.getFilename()));
         FindBuildsResult findBuildsResult = pncBuildFinder.findBuildsPnc(requestMap);
 
         // then
@@ -147,7 +147,7 @@ class PncBuildFinderTest {
     void shouldNotFindABuildInPnc() throws RemoteResourceException {
         // given
         String givenMd5 = "md5-different";
-        String filename = "empty.jar";
+        LocalFile filename = new LocalFile("empty.jar", 10L);
         Checksum checksum = new Checksum(ChecksumType.md5, givenMd5, filename);
 
         PncClient pncClient = Mockito.mock(PncClient.class);
@@ -159,7 +159,7 @@ class PncBuildFinderTest {
 
         // when
         Map<Checksum, Collection<String>> requestMap = Collections
-                .singletonMap(checksum, Collections.singletonList(filename));
+                .singletonMap(checksum, Collections.singletonList(filename.getFilename()));
         FindBuildsResult findBuildsResult = pncBuildFinder.findBuildsPnc(requestMap);
 
         // then
@@ -169,7 +169,7 @@ class PncBuildFinderTest {
 
         // Verify that the artifact is in the notFoundChecksums collection
         assertThat(findBuildsResult.getNotFoundChecksums(), is(aMapWithSize(1)));
-        assertThat(findBuildsResult.getNotFoundChecksums(), hasEntry(is(checksum), contains(filename)));
+        assertThat(findBuildsResult.getNotFoundChecksums(), hasEntry(is(checksum), contains(filename.getFilename())));
     }
 
     private static StaticRemoteCollection<Artifact> createArtifactsRemoteCollection(Artifact... artifacts) {

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/PncBuildFinderTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/PncBuildFinderTest.java
@@ -88,7 +88,7 @@ class PncBuildFinderTest {
     void shouldFindOneBuildInPnc() throws RemoteResourceException {
         // given
         String md5 = "md5-checksum";
-        LocalFile filename = new LocalFile("empty.jar", 10L);
+        LocalFile filename = new LocalFile("empty.jar", -1L);
         Checksum checksum = new Checksum(ChecksumType.md5, md5, filename);
         PncClient pncClient = Mockito.mock(PncClient.class);
         String buildId = "100";
@@ -147,7 +147,7 @@ class PncBuildFinderTest {
     void shouldNotFindABuildInPnc() throws RemoteResourceException {
         // given
         String givenMd5 = "md5-different";
-        LocalFile filename = new LocalFile("empty.jar", 10L);
+        LocalFile filename = new LocalFile("empty.jar", -1L);
         Checksum checksum = new Checksum(ChecksumType.md5, givenMd5, filename);
 
         PncClient pncClient = Mockito.mock(PncClient.class);

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/SkipImportTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/SkipImportTest.java
@@ -55,12 +55,12 @@ class SkipImportTest {
                 ChecksumType.md5,
                 "2e7e85f0ee97afde716231a6c792492a",
                 "commons-lang-2.6-redhat-2.jar",
-                10L);
+                287477L);
         Checksum checksum2 = new Checksum(
                 ChecksumType.md5,
                 "3b6a309e0dd4f488fd0cce429b44d067",
                 "commons-lang-2.6-redhat-2.pom",
-                10L);
+                17931L);
         List<Checksum> checksums = Arrays.asList(checksum1, checksum2);
         List<String> filenames1 = Collections.singletonList("commons-lang-2.6-redhat-2.jar");
         List<String> filenames2 = Collections.singletonList("commons-lang-2.6-redhat-2.pom");

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/SkipImportTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/SkipImportTest.java
@@ -54,11 +54,13 @@ class SkipImportTest {
         Checksum checksum1 = new Checksum(
                 ChecksumType.md5,
                 "2e7e85f0ee97afde716231a6c792492a",
-                "commons-lang-2.6-redhat-2.jar");
+                "commons-lang-2.6-redhat-2.jar",
+                10L);
         Checksum checksum2 = new Checksum(
                 ChecksumType.md5,
                 "3b6a309e0dd4f488fd0cce429b44d067",
-                "commons-lang-2.6-redhat-2.pom");
+                "commons-lang-2.6-redhat-2.pom",
+                10L);
         List<Checksum> checksums = Arrays.asList(checksum1, checksum2);
         List<String> filenames1 = Collections.singletonList("commons-lang-2.6-redhat-2.jar");
         List<String> filenames2 = Collections.singletonList("commons-lang-2.6-redhat-2.pom");

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/AbstractRpmIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/AbstractRpmIT.java
@@ -27,6 +27,7 @@ import org.jboss.pnc.build.finder.core.BuildFinder;
 import org.jboss.pnc.build.finder.core.BuildSystemInteger;
 import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.DistributionAnalyzer;
+import org.jboss.pnc.build.finder.core.LocalFile;
 import org.jboss.pnc.build.finder.koji.ClientSession;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.junit.jupiter.api.Test;
@@ -53,7 +54,7 @@ public abstract class AbstractRpmIT extends AbstractKojiIT {
         Timer timer = REGISTRY.timer(MetricRegistry.name(AbstractRpmIT.class, "checksums"));
         ExecutorService pool = Executors.newFixedThreadPool(2);
         DistributionAnalyzer analyzer;
-        Future<Map<ChecksumType, MultiValuedMap<String, String>>> futureChecksum;
+        Future<Map<ChecksumType, MultiValuedMap<String, LocalFile>>> futureChecksum;
 
         try (Timer.Context context = timer.time()) {
             analyzer = new DistributionAnalyzer(getFiles(), getConfig());
@@ -67,7 +68,7 @@ public abstract class AbstractRpmIT extends AbstractKojiIT {
             BuildFinder finder = new BuildFinder(session, getConfig(), analyzer, null, getPncClient());
             finder.setOutputDirectory(folder);
             Future<Map<BuildSystemInteger, KojiBuild>> futureBuilds = pool.submit(finder);
-            Map<ChecksumType, MultiValuedMap<String, String>> map = futureChecksum.get();
+            Map<ChecksumType, MultiValuedMap<String, LocalFile>> map = futureChecksum.get();
             Map<BuildSystemInteger, KojiBuild> builds = futureBuilds.get();
 
             verify(analyzer, finder);

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/FileErrorIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/FileErrorIT.java
@@ -115,17 +115,17 @@ class FileErrorIT extends AbstractKojiIT {
                     analyzer.getChecksums(ChecksumType.md5),
                     hasEntry(
                             is("ac2a6ab1fbf6afba37789e2e88a916a6"),
-                            contains("jboss-jaxb-intros-1.0.2.GA-sources.jar")));
+                            contains(hasProperty("filename", is("jboss-jaxb-intros-1.0.2.GA-sources.jar")))));
             assertThat(
                     analyzer.getChecksums(ChecksumType.sha1),
                     hasEntry(
                             is("ab2f490dd83035bee3a719d2118cbab90508082f"),
-                            contains("jboss-jaxb-intros-1.0.2.GA-sources.jar")));
+                            contains(hasProperty("filename", is("jboss-jaxb-intros-1.0.2.GA-sources.jar")))));
             assertThat(
                     analyzer.getChecksums(ChecksumType.sha256),
                     hasEntry(
                             is("987dd27e51ba77cb067dbec1baa5169eb184313688640e3951e3cb34d9a85c48"),
-                            contains("jboss-jaxb-intros-1.0.2.GA-sources.jar")));
+                            contains(hasProperty("filename", is("jboss-jaxb-intros-1.0.2.GA-sources.jar")))));
             assertThat(notFoundChecksums, is(anEmptyMap()));
             assertThat(foundChecksums, is(aMapWithSize(1)));
             assertThat(buildsFound, hasSize(1));

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/FileErrorIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/FileErrorIT.java
@@ -43,6 +43,7 @@ import org.jboss.pnc.build.finder.core.Checksum;
 import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.DistributionAnalyzer;
 import org.jboss.pnc.build.finder.core.FileError;
+import org.jboss.pnc.build.finder.core.LocalFile;
 import org.jboss.pnc.build.finder.koji.ClientSession;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.junit.jupiter.api.Test;
@@ -67,7 +68,7 @@ class FileErrorIT extends AbstractKojiIT {
         Timer timer = REGISTRY.timer(MetricRegistry.name(FileErrorIT.class, "checksums"));
         ExecutorService pool = Executors.newFixedThreadPool(2);
         DistributionAnalyzer analyzer;
-        Future<Map<ChecksumType, MultiValuedMap<String, String>>> futureChecksum;
+        Future<Map<ChecksumType, MultiValuedMap<String, LocalFile>>> futureChecksum;
 
         try (Timer.Context context = timer.time()) {
             analyzer = new DistributionAnalyzer(Collections.singletonList(URL), getConfig());
@@ -81,7 +82,7 @@ class FileErrorIT extends AbstractKojiIT {
             BuildFinder finder = new BuildFinder(session, getConfig(), analyzer, null, getPncClient());
             finder.setOutputDirectory(folder);
             Future<Map<BuildSystemInteger, KojiBuild>> futureBuilds = pool.submit(finder);
-            Map<ChecksumType, MultiValuedMap<String, String>> map = futureChecksum.get();
+            Map<ChecksumType, MultiValuedMap<String, LocalFile>> map = futureChecksum.get();
             Map<BuildSystemInteger, KojiBuild> builds = futureBuilds.get();
             Map<BuildSystemInteger, KojiBuild> buildsMap = finder.getBuildsMap();
             Collection<FileError> fileErrors = analyzer.getFileErrors();

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/FileErrorIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/FileErrorIT.java
@@ -115,17 +115,26 @@ class FileErrorIT extends AbstractKojiIT {
                     analyzer.getChecksums(ChecksumType.md5),
                     hasEntry(
                             is("ac2a6ab1fbf6afba37789e2e88a916a6"),
-                            contains(hasProperty("filename", is("jboss-jaxb-intros-1.0.2.GA-sources.jar")))));
+                            contains(
+                                    allOf(
+                                            hasProperty("filename", is("jboss-jaxb-intros-1.0.2.GA-sources.jar")),
+                                            hasProperty("size", is(29537L))))));
             assertThat(
                     analyzer.getChecksums(ChecksumType.sha1),
                     hasEntry(
                             is("ab2f490dd83035bee3a719d2118cbab90508082f"),
-                            contains(hasProperty("filename", is("jboss-jaxb-intros-1.0.2.GA-sources.jar")))));
+                            contains(
+                                    allOf(
+                                            hasProperty("filename", is("jboss-jaxb-intros-1.0.2.GA-sources.jar")),
+                                            hasProperty("size", is(29537L))))));
             assertThat(
                     analyzer.getChecksums(ChecksumType.sha256),
                     hasEntry(
                             is("987dd27e51ba77cb067dbec1baa5169eb184313688640e3951e3cb34d9a85c48"),
-                            contains(hasProperty("filename", is("jboss-jaxb-intros-1.0.2.GA-sources.jar")))));
+                            contains(
+                                    allOf(
+                                            hasProperty("filename", is("jboss-jaxb-intros-1.0.2.GA-sources.jar")),
+                                            hasProperty("size", is(29537L))))));
             assertThat(notFoundChecksums, is(anEmptyMap()));
             assertThat(foundChecksums, is(aMapWithSize(1)));
             assertThat(buildsFound, hasSize(1));

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/KojiBuildFinderIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/KojiBuildFinderIT.java
@@ -34,6 +34,7 @@ import org.jboss.pnc.build.finder.core.BuildFinder;
 import org.jboss.pnc.build.finder.core.BuildSystemInteger;
 import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.DistributionAnalyzer;
+import org.jboss.pnc.build.finder.core.LocalFile;
 import org.jboss.pnc.build.finder.koji.ClientSession;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.junit.jupiter.api.Test;
@@ -64,13 +65,13 @@ class KojiBuildFinderIT extends AbstractKojiIT {
 
         Timer timer = REGISTRY.timer(MetricRegistry.name(KojiBuildFinderIT.class, "checksums"));
 
-        Map<ChecksumType, MultiValuedMap<String, String>> map;
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> map;
 
         ExecutorService pool = Executors.newFixedThreadPool(2);
 
         DistributionAnalyzer analyzer;
 
-        Future<Map<ChecksumType, MultiValuedMap<String, String>>> futureChecksum;
+        Future<Map<ChecksumType, MultiValuedMap<String, LocalFile>>> futureChecksum;
 
         try (Timer.Context context = timer.time()) {
             analyzer = new DistributionAnalyzer(Collections.singletonList(URL), getConfig());

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmBuildIdNotFoundIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmBuildIdNotFoundIT.java
@@ -37,6 +37,7 @@ import org.jboss.pnc.build.finder.core.Checksum;
 import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.DistributionAnalyzer;
 import org.jboss.pnc.build.finder.core.FileError;
+import org.jboss.pnc.build.finder.core.LocalFile;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +58,7 @@ class RpmBuildIdNotFoundIT extends AbstractRpmIT {
         Map<Checksum, Collection<String>> foundChecksums = finder.getFoundChecksums();
         Map<Checksum, Collection<String>> notFoundChecksums = finder.getNotFoundChecksums();
         List<KojiBuild> buildsFound = finder.getBuildsFound();
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = analyzer.getChecksums();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = analyzer.getChecksums();
         Map<BuildSystemInteger, KojiBuild> builds = finder.getBuildsMap();
 
         assertThat(checksums, is(aMapWithSize(3)));

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmBuildIdNotFoundIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmBuildIdNotFoundIT.java
@@ -66,7 +66,9 @@ class RpmBuildIdNotFoundIT extends AbstractRpmIT {
         assertThat(fileErrors, is(empty()));
         assertThat(
                 analyzer.getChecksums(ChecksumType.md5),
-                hasEntry(is("84ed0982a77b1c3a0c093409eb19c8ab"), contains("libdnf-0.48.0-4.fc33.x86_64.rpm")));
+                hasEntry(
+                        is("84ed0982a77b1c3a0c093409eb19c8ab"),
+                        contains(hasProperty("filename", is("libdnf-0.48.0-4.fc33.x86_64.rpm")))));
         assertThat(notFoundChecksums, is(anEmptyMap()));
         assertThat(
                 files,

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmBuildIdNotFoundIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmBuildIdNotFoundIT.java
@@ -68,7 +68,10 @@ class RpmBuildIdNotFoundIT extends AbstractRpmIT {
                 analyzer.getChecksums(ChecksumType.md5),
                 hasEntry(
                         is("84ed0982a77b1c3a0c093409eb19c8ab"),
-                        contains(hasProperty("filename", is("libdnf-0.48.0-4.fc33.x86_64.rpm")))));
+                        contains(
+                                allOf(
+                                        hasProperty("filename", is("libdnf-0.48.0-4.fc33.x86_64.rpm")),
+                                        hasProperty("size", is(605175L))))));
         assertThat(notFoundChecksums, is(anEmptyMap()));
         assertThat(
                 files,

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmIT.java
@@ -66,7 +66,9 @@ class RpmIT extends AbstractRpmIT {
         assertThat(fileErrors, is(empty()));
         assertThat(
                 analyzer.getChecksums(ChecksumType.md5),
-                hasEntry(is("31bc067a6462aacd3b891681bdb27512"), contains("basesystem-11-5.el8.noarch.rpm")));
+                hasEntry(
+                        is("31bc067a6462aacd3b891681bdb27512"),
+                        contains(hasProperty("filename", is("basesystem-11-5.el8.noarch.rpm")))));
         assertThat(
                 files,
                 allOf(

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmIT.java
@@ -68,7 +68,10 @@ class RpmIT extends AbstractRpmIT {
                 analyzer.getChecksums(ChecksumType.md5),
                 hasEntry(
                         is("31bc067a6462aacd3b891681bdb27512"),
-                        contains(hasProperty("filename", is("basesystem-11-5.el8.noarch.rpm")))));
+                        contains(
+                                allOf(
+                                        hasProperty("filename", is("basesystem-11-5.el8.noarch.rpm")),
+                                        hasProperty("size", is(10756L))))));
         assertThat(
                 files,
                 allOf(

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmIT.java
@@ -37,6 +37,7 @@ import org.jboss.pnc.build.finder.core.Checksum;
 import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.DistributionAnalyzer;
 import org.jboss.pnc.build.finder.core.FileError;
+import org.jboss.pnc.build.finder.core.LocalFile;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +58,7 @@ class RpmIT extends AbstractRpmIT {
         Map<Checksum, Collection<String>> foundChecksums = finder.getFoundChecksums();
         Map<Checksum, Collection<String>> notFoundChecksums = finder.getNotFoundChecksums();
         List<KojiBuild> buildsFound = finder.getBuildsFound();
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = analyzer.getChecksums();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = analyzer.getChecksums();
         Map<BuildSystemInteger, KojiBuild> builds = finder.getBuildsMap();
 
         assertThat(checksums, is(aMapWithSize(3)));

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmNvrNotFoundIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmNvrNotFoundIT.java
@@ -75,7 +75,7 @@ class RpmNvrNotFoundIT extends AbstractRpmIT {
                 analyzer.getChecksums(ChecksumType.md5),
                 hasEntry(
                         is("aa585b870f59ef457f26fa32a0daf923"),
-                        contains("java-11-openjdk-11.0.8.10-1.fc33.x86_64.rpm")));
+                        contains(hasProperty("filename", is("java-11-openjdk-11.0.8.10-1.fc33.x86_64.rpm")))));
         assertThat(
                 notFoundChecksums,
                 allOf(

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmNvrNotFoundIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmNvrNotFoundIT.java
@@ -37,6 +37,7 @@ import org.jboss.pnc.build.finder.core.Checksum;
 import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.DistributionAnalyzer;
 import org.jboss.pnc.build.finder.core.FileError;
+import org.jboss.pnc.build.finder.core.LocalFile;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +58,7 @@ class RpmNvrNotFoundIT extends AbstractRpmIT {
         Map<Checksum, Collection<String>> foundChecksums = finder.getFoundChecksums();
         Map<Checksum, Collection<String>> notFoundChecksums = finder.getNotFoundChecksums();
         List<KojiBuild> buildsFound = finder.getBuildsFound();
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = analyzer.getChecksums();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = analyzer.getChecksums();
         Map<BuildSystemInteger, KojiBuild> builds = finder.getBuildsMap();
 
         assertThat(checksums, is(aMapWithSize(3)));

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmNvrNotFoundIT.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/it/RpmNvrNotFoundIT.java
@@ -75,7 +75,10 @@ class RpmNvrNotFoundIT extends AbstractRpmIT {
                 analyzer.getChecksums(ChecksumType.md5),
                 hasEntry(
                         is("aa585b870f59ef457f26fa32a0daf923"),
-                        contains(hasProperty("filename", is("java-11-openjdk-11.0.8.10-1.fc33.x86_64.rpm")))));
+                        contains(
+                                allOf(
+                                        hasProperty("filename", is("java-11-openjdk-11.0.8.10-1.fc33.x86_64.rpm")),
+                                        hasProperty("size", is(258129L))))));
         assertThat(
                 notFoundChecksums,
                 allOf(

--- a/report/src/test/java/org/jboss/pnc/build/finder/report/it/ReportIT.java
+++ b/report/src/test/java/org/jboss/pnc/build/finder/report/it/ReportIT.java
@@ -36,6 +36,7 @@ import org.jboss.pnc.build.finder.core.BuildFinder;
 import org.jboss.pnc.build.finder.core.BuildSystemInteger;
 import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.DistributionAnalyzer;
+import org.jboss.pnc.build.finder.core.LocalFile;
 import org.jboss.pnc.build.finder.core.it.AbstractKojiIT;
 import org.jboss.pnc.build.finder.koji.ClientSession;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
@@ -69,13 +70,13 @@ class ReportIT extends AbstractKojiIT {
 
         Timer timer = REGISTRY.timer(MetricRegistry.name(ReportIT.class, "checksums"));
 
-        Map<ChecksumType, MultiValuedMap<String, String>> map;
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> map;
 
         ExecutorService pool = Executors.newFixedThreadPool(2);
 
         DistributionAnalyzer analyzer;
 
-        Future<Map<ChecksumType, MultiValuedMap<String, String>>> futureChecksum;
+        Future<Map<ChecksumType, MultiValuedMap<String, LocalFile>>> futureChecksum;
 
         try (Timer.Context context = timer.time()) {
             analyzer = new DistributionAnalyzer(Collections.singletonList(URL), getConfig());

--- a/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmBuildIdNotFoundReportIT.java
+++ b/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmBuildIdNotFoundReportIT.java
@@ -79,7 +79,9 @@ class RpmBuildIdNotFoundReportIT extends AbstractRpmIT {
         assertThat(fileErrors, is(empty()));
         assertThat(
                 analyzer.getChecksums(ChecksumType.md5),
-                hasEntry(is("84ed0982a77b1c3a0c093409eb19c8ab"), contains("libdnf-0.48.0-4.fc33.x86_64.rpm")));
+                hasEntry(
+                        is("84ed0982a77b1c3a0c093409eb19c8ab"),
+                        contains(hasProperty("filename", is("libdnf-0.48.0-4.fc33.x86_64.rpm")))));
         assertThat(notFoundChecksums, is(anEmptyMap()));
         assertThat(
                 files,

--- a/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmBuildIdNotFoundReportIT.java
+++ b/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmBuildIdNotFoundReportIT.java
@@ -81,7 +81,10 @@ class RpmBuildIdNotFoundReportIT extends AbstractRpmIT {
                 analyzer.getChecksums(ChecksumType.md5),
                 hasEntry(
                         is("84ed0982a77b1c3a0c093409eb19c8ab"),
-                        contains(hasProperty("filename", is("libdnf-0.48.0-4.fc33.x86_64.rpm")))));
+                        contains(
+                                allOf(
+                                        hasProperty("filename", is("libdnf-0.48.0-4.fc33.x86_64.rpm")),
+                                        hasProperty("size", is(605175L))))));
         assertThat(notFoundChecksums, is(anEmptyMap()));
         assertThat(
                 files,

--- a/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmBuildIdNotFoundReportIT.java
+++ b/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmBuildIdNotFoundReportIT.java
@@ -45,6 +45,7 @@ import org.jboss.pnc.build.finder.core.Checksum;
 import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.DistributionAnalyzer;
 import org.jboss.pnc.build.finder.core.FileError;
+import org.jboss.pnc.build.finder.core.LocalFile;
 import org.jboss.pnc.build.finder.core.it.AbstractRpmIT;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.jboss.pnc.build.finder.report.Report;
@@ -67,7 +68,7 @@ class RpmBuildIdNotFoundReportIT extends AbstractRpmIT {
         Map<Checksum, Collection<String>> foundChecksums = finder.getFoundChecksums();
         Map<Checksum, Collection<String>> notFoundChecksums = finder.getNotFoundChecksums();
         List<KojiBuild> buildsFound = finder.getBuildsFound();
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = analyzer.getChecksums();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = analyzer.getChecksums();
         Map<BuildSystemInteger, KojiBuild> builds = finder.getBuildsMap();
 
         assertThat(checksums, is(aMapWithSize(3)));

--- a/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmReportIT.java
+++ b/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmReportIT.java
@@ -79,7 +79,10 @@ class RpmReportIT extends AbstractRpmIT {
                 analyzer.getChecksums(ChecksumType.md5),
                 hasEntry(
                         is("31bc067a6462aacd3b891681bdb27512"),
-                        contains(hasProperty("filename", is("basesystem-11-5.el8.noarch.rpm")))));
+                        contains(
+                                allOf(
+                                        hasProperty("filename", is("basesystem-11-5.el8.noarch.rpm")),
+                                        hasProperty("size", is(10756L))))));
         assertThat(
                 files,
                 allOf(

--- a/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmReportIT.java
+++ b/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmReportIT.java
@@ -77,7 +77,9 @@ class RpmReportIT extends AbstractRpmIT {
         assertThat(fileErrors, is(empty()));
         assertThat(
                 analyzer.getChecksums(ChecksumType.md5),
-                hasEntry(is("31bc067a6462aacd3b891681bdb27512"), contains("basesystem-11-5.el8.noarch.rpm")));
+                hasEntry(
+                        is("31bc067a6462aacd3b891681bdb27512"),
+                        contains(hasProperty("filename", is("basesystem-11-5.el8.noarch.rpm")))));
         assertThat(
                 files,
                 allOf(

--- a/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmReportIT.java
+++ b/report/src/test/java/org/jboss/pnc/build/finder/report/it/RpmReportIT.java
@@ -46,6 +46,7 @@ import org.jboss.pnc.build.finder.core.Checksum;
 import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.DistributionAnalyzer;
 import org.jboss.pnc.build.finder.core.FileError;
+import org.jboss.pnc.build.finder.core.LocalFile;
 import org.jboss.pnc.build.finder.core.it.AbstractRpmIT;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.jboss.pnc.build.finder.report.Report;
@@ -68,7 +69,7 @@ class RpmReportIT extends AbstractRpmIT {
         Map<Checksum, Collection<String>> foundChecksums = finder.getFoundChecksums();
         Map<Checksum, Collection<String>> notFoundChecksums = finder.getNotFoundChecksums();
         List<KojiBuild> buildsFound = finder.getBuildsFound();
-        Map<ChecksumType, MultiValuedMap<String, String>> checksums = analyzer.getChecksums();
+        Map<ChecksumType, MultiValuedMap<String, LocalFile>> checksums = analyzer.getChecksums();
         Map<BuildSystemInteger, KojiBuild> builds = finder.getBuildsMap();
 
         assertThat(checksums, is(aMapWithSize(3)));


### PR DESCRIPTION
This is a breaking change for 3 reasons:
1. checksums-* files now store filesize which is a format change therefore breaking
2. Infinispan cache has a changed format too because of additionally storing information about size (now it stores a Class instead of simple String) which is also a format change. This means that the already built caches need to be dropped.
3. DistributionAnalyzer API has changed