### PR TITLE
[NCL-5611] Use BasicCacheContainer

### DIFF
--- a/core/src/main/java/org/jboss/pnc/build/finder/core/BuildFinder.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/BuildFinder.java
@@ -48,8 +48,8 @@ import java.util.stream.Stream;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
-import org.infinispan.Cache;
-import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.commons.api.BasicCache;
+import org.infinispan.commons.api.BasicCacheContainer;
 import org.jboss.pnc.build.finder.koji.ClientSession;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.jboss.pnc.build.finder.koji.KojiLocalArchive;
@@ -92,13 +92,13 @@ public class BuildFinder implements Callable<Map<BuildSystemInteger, KojiBuild>>
 
     private final DistributionAnalyzer analyzer;
 
-    private Map<ChecksumType, Cache<String, List<KojiArchiveInfo>>> checksumCaches;
+    private Map<ChecksumType, BasicCache<String, List<KojiArchiveInfo>>> checksumCaches;
 
-    private Cache<Integer, KojiBuild> buildCache;
+    private BasicCache<Integer, KojiBuild> buildCache;
 
-    private Map<ChecksumType, Cache<String, KojiBuild>> rpmCaches;
+    private Map<ChecksumType, BasicCache<String, KojiBuild>> rpmCaches;
 
-    private final EmbeddedCacheManager cacheManager;
+    private final BasicCacheContainer cacheManager;
 
     private final PncBuildFinder pncBuildFinder;
 
@@ -122,7 +122,7 @@ public class BuildFinder implements Callable<Map<BuildSystemInteger, KojiBuild>>
             ClientSession session,
             BuildConfig config,
             DistributionAnalyzer analyzer,
-            EmbeddedCacheManager cacheManager) {
+            BasicCacheContainer cacheManager) {
         this(session, config, analyzer, cacheManager, null);
     }
 
@@ -130,7 +130,7 @@ public class BuildFinder implements Callable<Map<BuildSystemInteger, KojiBuild>>
             ClientSession session,
             BuildConfig config,
             DistributionAnalyzer analyzer,
-            EmbeddedCacheManager cacheManager,
+            BasicCacheContainer cacheManager,
             PncClient pncclient) {
         this.session = session;
         this.config = config;

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/DistributionAnalyzer.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/DistributionAnalyzer.java
@@ -56,8 +56,8 @@ import org.apache.commons.vfs2.FileSystem;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.commons.vfs2.provider.http5.Http5FileProvider;
-import org.infinispan.Cache;
-import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.commons.api.BasicCache;
+import org.infinispan.commons.api.BasicCacheContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,9 +81,9 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
 
     private final BuildConfig config;
 
-    private final Map<ChecksumType, Cache<String, MultiValuedMap<String, LocalFile>>> fileCaches;
+    private final Map<ChecksumType, BasicCache<String, MultiValuedMap<String, LocalFile>>> fileCaches;
 
-    private final EmbeddedCacheManager cacheManager;
+    private final BasicCacheContainer cacheManager;
 
     private final AtomicInteger level;
 
@@ -107,7 +107,7 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
         this(inputs, config, null);
     }
 
-    public DistributionAnalyzer(List<String> inputs, BuildConfig config, EmbeddedCacheManager cacheManager) {
+    public DistributionAnalyzer(List<String> inputs, BuildConfig config, BasicCacheContainer cacheManager) {
         this.inputs = inputs;
         this.config = config;
         checksumTypesToCheck = EnumSet.copyOf(config.getChecksumTypes());


### PR DESCRIPTION
This is done for `BuildFinder` and `DistributionAnalyzer` so that they
can accept either an embedded cache or a remote cache. The 2 types of
cache managers hav2 as base interface `BasicCacheContainer`.