### PR TITLE
Bump infinispan version to 12.1.7.Final

### DIFF
--- a/build-finder/pom.xml
+++ b/build-finder/pom.xml
@@ -92,6 +92,12 @@
                   </includes>
                 </filter>
                 <filter>
+                  <artifact>org.infinispan:infinispan-commons-jdk11</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
                   <artifact>org.infinispan:infinispan-core</artifact>
                   <includes>
                     <include>**</include>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-commons-jdk11</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
       <artifactId>infinispan-core</artifactId>
     </dependency>
     <dependency>

--- a/cli/src/main/java/org/jboss/pnc/build/finder/cli/Main.java
+++ b/cli/src/main/java/org/jboss/pnc/build/finder/cli/Main.java
@@ -433,7 +433,7 @@ public final class Main implements Callable<Void> {
                 .marshaller(new GenericJBossMarshaller())
                 .addAdvancedExternalizer(kojiBuildExternalizer.getId(), kojiBuildExternalizer)
                 .addAdvancedExternalizer(localFileExternalizer.getId(), localFileExternalizer)
-                .whiteList()
+                .allowList()
                 .addRegexp(".*")
                 .create();
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -84,6 +84,10 @@
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-commons-jdk11</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
       <artifactId>infinispan-component-annotations</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <version.org.ec4j.maven.editorconfig-maven-plugin>0.1.1</version.org.ec4j.maven.editorconfig-maven-plugin>
     <version.org.eclipse.packager>0.17.0</version.org.eclipse.packager>
     <version.org.fusesource.jansi>2.3.4</version.org.fusesource.jansi>
-    <version.org.infinispan>11.0.11.Final</version.org.infinispan>
+    <version.org.infinispan>12.1.7.Final</version.org.infinispan>
     <version.org.jacoco>0.8.7</version.org.jacoco>
     <version.org.jboss.byteman>4.0.16</version.org.jboss.byteman>
     <version.org.jboss.logmanager>2.1.18.Final</version.org.jboss.logmanager>
@@ -276,6 +276,12 @@
         <groupId>org.fusesource.jansi</groupId>
         <artifactId>jansi</artifactId>
         <version>${version.org.fusesource.jansi}</version>
+      </dependency>
+      <!-- added since not part of infinispan-bom as of 12.1.7.Final -->
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-commons-jdk11</artifactId>
+        <version>${version.org.infinispan}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.pnc</groupId>


### PR DESCRIPTION
    The infinispan-commons-jdk11 is added to include a class referred in the
    infinispan-commons library's META-INF/services file. It seems like
    there's a packaging issue on the infinispan-commons side where the
    services file refers to a class only present in
    infinispan-commons-jdk11, but the latter is not part of the runtime
    dependencies, nor in the infinispan BOM.
