### PR TITLE
Refactor DistributionAnalyzer

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -24,4 +24,8 @@
     <Class name="org.jboss.pnc.build.finder.cli.Main"/>
     <Bug pattern="DM_EXIT,RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
   </Match>
+  <Match>
+    <Class name="org.jboss.pnc.build.finder.core.DistributionAnalyzer"/>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
This commit is a pure refactoring of DistributionAnalyzer. No new logic
is added.

Goals:
- use try with resources for StandardFileSystemManager and FileObject
- Keep the StandardFileSystemManager inside the `checksumFiles` method

The latter is done because the manager shouldn't be shared freely inside the
DistributionAnalyzer object. The lifecycle of the manager is wholy
inside the `checksumFiles` method, it is created and closed in it. As
such, if the manager is freely accessible to other methods, there's a
risk the other methods will invoke the manager when it's already closed.

Instead, the manager is passed around other methods that requires its
use.

The try-with-resources is triggering a false positive on spotbugs
concerning the redundant null check, which is why the exclusion is added.