### PR TITLE
[NCL-5611] Protobuf for LocalFile / KojiBuild

### DIFF
--- a/cli/src/main/java/org/jboss/pnc/build/finder/cli/Main.java
+++ b/cli/src/main/java/org/jboss/pnc/build/finder/cli/Main.java
@@ -49,7 +49,6 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationChildBuilder;
-import org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.pnc.build.finder.core.BuildConfig;
@@ -68,6 +67,7 @@ import org.jboss.pnc.build.finder.koji.KojiClientSession;
 import org.jboss.pnc.build.finder.koji.KojiJSONUtils;
 import org.jboss.pnc.build.finder.pnc.client.HashMapCachingPncClient;
 import org.jboss.pnc.build.finder.pnc.client.PncClient;
+import org.jboss.pnc.build.finder.protobuf.ProtobufSerializerImpl;
 import org.jboss.pnc.build.finder.report.Report;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -422,17 +422,13 @@ public final class Main implements Callable<Void> {
     }
 
     private void initCaches(BuildConfig config) {
-        KojiBuild.KojiBuildExternalizer kojiBuildExternalizer = new KojiBuild.KojiBuildExternalizer();
-        LocalFile.LocalFileExternalizer localFileExternalizer = new LocalFile.LocalFileExternalizer();
         GlobalConfigurationChildBuilder globalConfig = new GlobalConfigurationBuilder();
         String location = new File(ConfigDefaults.CACHE_LOCATION).getAbsolutePath();
 
         globalConfig.globalState()
                 .persistentLocation(location)
                 .serialization()
-                .marshaller(new GenericJBossMarshaller())
-                .addAdvancedExternalizer(kojiBuildExternalizer.getId(), kojiBuildExternalizer)
-                .addAdvancedExternalizer(localFileExternalizer.getId(), localFileExternalizer)
+                .addContextInitializer(new ProtobufSerializerImpl())
                 .allowList()
                 .addRegexp(".*")
                 .create();

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/BuildFinder.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/BuildFinder.java
@@ -596,11 +596,17 @@ public class BuildFinder implements Callable<Map<BuildSystemInteger, KojiBuild>>
                     buildCache.put(cacheRpmBuildInfo.getBuildInfo().getId(), cacheRpmBuildInfo);
                 }
             } else {
-                if (cacheManager == null || checksumCaches.get(ChecksumType.md5).get(checksum.getValue()) == null) {
+                ListKojiArchiveInfoProtobufWrapper wrapper = null;
+
+                if (checksumCaches != null) {
+                    wrapper = checksumCaches.get(ChecksumType.md5).get(checksum.getValue());
+                }
+
+                if (cacheManager == null || wrapper == null) {
                     LOGGER.debug("Add checksum {} to list", checksum);
                     checksums.add(entry);
                 } else {
-                    cacheArchiveInfos = checksumCaches.get(ChecksumType.md5).get(checksum.getValue()).getData();
+                    cacheArchiveInfos = wrapper.getData();
                     LOGGER.debug(
                             "Checksum {} cached with build ids {}",
                             green(checksum),

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/DistributionAnalyzer.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/DistributionAnalyzer.java
@@ -59,6 +59,7 @@ import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.commons.vfs2.provider.http5.Http5FileProvider;
 import org.infinispan.commons.api.BasicCache;
 import org.infinispan.commons.api.BasicCacheContainer;
+import org.jboss.pnc.build.finder.protobuf.MultiValuedMapProtobufWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +83,7 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
 
     private final BuildConfig config;
 
-    private final Map<ChecksumType, BasicCache<String, MultiValuedMap<String, LocalFile>>> fileCaches;
+    private final Map<ChecksumType, BasicCache<String, MultiValuedMapProtobufWrapper<String, LocalFile>>> fileCaches;
 
     private final BasicCacheContainer cacheManager;
 
@@ -243,7 +244,10 @@ public class DistributionAnalyzer implements Callable<Map<ChecksumType, MultiVal
                                 Optional<Checksum> cksum = Checksum.findByType(fileChecksums, checksumType);
 
                                 if (cksum.isPresent()) {
-                                    fileCaches.get(checksumType).put(cksum.get().getValue(), map.get(checksumType));
+                                    fileCaches.get(checksumType)
+                                            .put(
+                                                    cksum.get().getValue(),
+                                                    new MultiValuedMapProtobufWrapper<>(map.get(checksumType)));
                                 } else {
                                     throw new IOException("Checksum type " + checksumType + " not found");
                                 }

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/LocalFile.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/LocalFile.java
@@ -15,14 +15,6 @@
  */
 package org.jboss.pnc.build.finder.core;
 
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.Set;
-
-import org.infinispan.commons.marshall.AdvancedExternalizer;
-import org.infinispan.commons.marshall.SerializeWith;
-import org.infinispan.commons.util.Util;
 import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoField;
 
@@ -31,8 +23,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize
-// TODO: Remove this annotation once conversion to protobuf is done
-@SerializeWith(LocalFile.LocalFileExternalizer.class)
 public class LocalFile {
     private final String filename;
 
@@ -58,46 +48,5 @@ public class LocalFile {
     @Override
     public String toString() {
         return "LocalFile{" + "filename='" + filename + '\'' + ", size=" + size + '}';
-    }
-
-    // TODO: Remove this class once conversion to protobuf is done
-    public static class LocalFileExternalizer implements AdvancedExternalizer<LocalFile> {
-        private static final long serialVersionUID = -3322870654564600039L;
-
-        private static final Integer ID = (Character.getNumericValue('L') << 16) | (Character.getNumericValue('F') << 8)
-                | Character.getNumericValue('E');
-
-        private static final int VERSION = 1;
-
-        @Override
-        public void writeObject(ObjectOutput output, LocalFile object) throws IOException {
-            output.writeInt(VERSION);
-            output.writeUTF(object.getFilename());
-            output.writeLong(object.getSize());
-        }
-
-        @Override
-        public LocalFile readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-            int version = input.readInt();
-
-            if (version != VERSION) {
-                throw new IOException("Invalid version: " + version);
-            }
-
-            String filename = input.readUTF();
-            long size = input.readLong();
-
-            return new LocalFile(filename, size);
-        }
-
-        @Override
-        public Set<Class<? extends LocalFile>> getTypeClasses() {
-            return Util.asSet(LocalFile.class);
-        }
-
-        @Override
-        public Integer getId() {
-            return ID;
-        }
     }
 }

--- a/core/src/main/java/org/jboss/pnc/build/finder/koji/KojiBuild.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/koji/KojiBuild.java
@@ -15,18 +15,10 @@
  */
 package org.jboss.pnc.build.finder.koji;
 
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-
-import org.infinispan.commons.marshall.AdvancedExternalizer;
-import org.infinispan.commons.marshall.SerializeWith;
-import org.infinispan.commons.util.Util;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.redhat.red.build.koji.model.json.KojiJsonConstants;
@@ -38,7 +30,6 @@ import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiTaskInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiTaskRequest;
 
-@SerializeWith(KojiBuild.KojiBuildExternalizer.class)
 public class KojiBuild {
     public static final String KEY_VERSION = "version";
 
@@ -302,59 +293,5 @@ public class KojiBuild {
         return "KojiBuild [buildInfo=" + buildInfo + ", taskInfo=" + taskInfo + ", taskRequest=" + taskRequest
                 + ", archives=" + archives + ", remoteArchives=" + remoteArchives + ", tags=" + tags + ", remoteRpms="
                 + remoteRpms + ", duplicateArchives=" + duplicateArchives + "]";
-    }
-
-    public static class KojiBuildExternalizer implements AdvancedExternalizer<KojiBuild> {
-        private static final long serialVersionUID = 8698588352614405297L;
-
-        private static final int VERSION = 2;
-
-        private static final Integer ID = (Character.getNumericValue('K') << 16) | (Character.getNumericValue('B') << 8)
-                | Character.getNumericValue('F');
-
-        @Override
-        public void writeObject(ObjectOutput output, KojiBuild object) throws IOException {
-            output.writeInt(VERSION);
-            output.writeObject(object.getBuildInfo());
-            output.writeObject(object.getTaskInfo());
-            output.writeObject(object.getRemoteArchives());
-            output.writeObject(object.getTags());
-            output.writeObject(object.getTypes());
-            output.writeObject(object.getRemoteRpms());
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public KojiBuild readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-            int version = input.readInt();
-
-            if (version != 1 && version != 2) {
-                throw new IOException("Invalid version: " + version);
-            }
-
-            KojiBuild build = new KojiBuild();
-
-            build.setBuildInfo((KojiBuildInfo) input.readObject());
-            build.setTaskInfo((KojiTaskInfo) input.readObject());
-            build.setRemoteArchives((List<KojiArchiveInfo>) input.readObject());
-            build.setTags((List<KojiTagInfo>) input.readObject());
-            build.setTypes((List<String>) input.readObject());
-
-            if (version > 1) {
-                build.setRemoteRpms((List<KojiRpmInfo>) input.readObject());
-            }
-
-            return build;
-        }
-
-        @Override
-        public Set<Class<? extends KojiBuild>> getTypeClasses() {
-            return Util.asSet(KojiBuild.class);
-        }
-
-        @Override
-        public Integer getId() {
-            return ID;
-        }
     }
 }

--- a/core/src/main/java/org/jboss/pnc/build/finder/protobuf/KojiArchiveInfoAdapter.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/protobuf/KojiArchiveInfoAdapter.java
@@ -25,7 +25,8 @@ import com.redhat.red.build.koji.model.json.util.KojiObjectMapper;
 import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
 
 /**
- * Protostream adapter to be able to properly marshall / unmarshall KojiArchiveInfo.
+ * Protostream adapter to be able to properly marshall/unmarshall
+ * {@link com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo}.
  *
  * This class is defined in Kojiji and can't be easily modified to add Proto annotations. Instead, the marshalling
  * process involves converting KojiArchiveInfo object into JSON and stored in Protobuf as a string. The unmarshalling

--- a/core/src/main/java/org/jboss/pnc/build/finder/protobuf/KojiArchiveInfoAdapter.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/protobuf/KojiArchiveInfoAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.build.finder.protobuf;
+
+import org.infinispan.protostream.annotations.ProtoAdapter;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.red.build.koji.model.json.util.KojiObjectMapper;
+import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
+
+/**
+ * Protostream adapter to be able to properly marshall / unmarshall KojiArchiveInfo.
+ *
+ * This class is defined in Kojiji and can't be easily modified to add Proto annotations. Instead, the marshalling
+ * process involves converting KojiArchiveInfo object into JSON and stored in Protobuf as a string. The unmarshalling
+ * process involves reading the JSON string from Protobuf and converting it back to a KojiArchiveInfo object.
+ */
+@ProtoAdapter(KojiArchiveInfo.class)
+public class KojiArchiveInfoAdapter {
+    private static final ObjectMapper OBJECT_MAPPER = new KojiObjectMapper();
+
+    @ProtoFactory
+    KojiArchiveInfo create(String jsonData) {
+        try {
+            return OBJECT_MAPPER.readValue(jsonData, KojiArchiveInfo.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @ProtoField(1)
+    String getJsonData(KojiArchiveInfo kojiArchiveInfo) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(kojiArchiveInfo);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/pnc/build/finder/protobuf/KojiBuildAdapter.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/protobuf/KojiBuildAdapter.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.red.build.koji.model.json.util.KojiObjectMapper;
 
 /**
- * Protostream adapter to be able to properly marshall / unmarshall KojiArchiveInfo.
+ * Protostream adapter to be able to properly marshall/unmarshall {@link org.jboss.pnc.build.finder.koji.KojiBuild}.
  *
  * This class uses several classes defined in Kojiji and can't be easily modified to add Proto annotations. Instead, the
  * marshalling process involves converting KojiBuild object into JSON and stored in Protobuf as a string. The

--- a/core/src/main/java/org/jboss/pnc/build/finder/protobuf/KojiBuildAdapter.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/protobuf/KojiBuildAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.build.finder.protobuf;
+
+import org.infinispan.protostream.annotations.ProtoAdapter;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.jboss.pnc.build.finder.koji.KojiBuild;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.red.build.koji.model.json.util.KojiObjectMapper;
+
+/**
+ * Protostream adapter to be able to properly marshall / unmarshall KojiArchiveInfo.
+ *
+ * This class uses several classes defined in Kojiji and can't be easily modified to add Proto annotations. Instead, the
+ * marshalling process involves converting KojiBuild object into JSON and stored in Protobuf as a string. The
+ * unmarshalling process involves reading the JSON string from Protobuf and converting it back to a KojiBuild object.
+ */
+@ProtoAdapter(KojiBuild.class)
+public class KojiBuildAdapter {
+    private static final ObjectMapper OBJECT_MAPPER = new KojiObjectMapper();
+
+    @ProtoFactory
+    KojiBuild create(String jsonData) {
+        try {
+            return OBJECT_MAPPER.readValue(jsonData, KojiBuild.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @ProtoField(number = 1, required = true)
+    String getJsonData(KojiBuild kojiBuild) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(kojiBuild);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/pnc/build/finder/protobuf/ListKojiArchiveInfoProtobufWrapper.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/protobuf/ListKojiArchiveInfoProtobufWrapper.java
@@ -16,6 +16,7 @@
 package org.jboss.pnc.build.finder.protobuf;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.infinispan.protostream.annotations.ProtoFactory;
@@ -24,15 +25,19 @@ import org.infinispan.protostream.annotations.ProtoField;
 import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
 
 /**
- * Class to wrap around a List of KojiArchiveInfo. This is used so that Protostream can properly marshall / unmarshall
- * the list and avoid this Protostream bug (https://issues.redhat.com/browse/IPROTO-219).
+ * Class to wrap around a List of {@link com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo}. This is used so that
+ * Protostream can properly marshall/unmarshall the list and avoid this Protostream bug
+ * (<a href="https://issues.redhat.com/browse/IPROTO-219">IPROTO-219</a>).
+ *
+ * @see <a href="https://issues.redhat.com/browse/IPROTO-219">IPROTO-219</a>
  */
 public class ListKojiArchiveInfoProtobufWrapper {
     /**
      * We cannot use Collections.emptyList because Protostream has no idea how to marshall it. Instead, we use an empty
      * ArrayList.
      */
-    private List<KojiArchiveInfo> data = new ArrayList<>(0);
+    private static final List<KojiArchiveInfo> EMPTY_LIST = Collections.unmodifiableList(new ArrayList<>(0));
+    private List<KojiArchiveInfo> data;
 
     public ListKojiArchiveInfoProtobufWrapper() {
 
@@ -45,6 +50,6 @@ public class ListKojiArchiveInfoProtobufWrapper {
 
     @ProtoField(1)
     public List<KojiArchiveInfo> getData() {
-        return data;
+        return data == null ? EMPTY_LIST : data;
     }
 }

--- a/core/src/main/java/org/jboss/pnc/build/finder/protobuf/ListKojiArchiveInfoProtobufWrapper.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/protobuf/ListKojiArchiveInfoProtobufWrapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.build.finder.protobuf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
+
+/**
+ * Class to wrap around a List of KojiArchiveInfo. This is used so that Protostream can properly marshall / unmarshall
+ * the list and avoid this Protostream bug (https://issues.redhat.com/browse/IPROTO-219).
+ */
+public class ListKojiArchiveInfoProtobufWrapper {
+    /**
+     * We cannot use Collections.emptyList because Protostream has no idea how to marshall it. Instead, we use an empty
+     * ArrayList.
+     */
+    private List<KojiArchiveInfo> data = new ArrayList<>(0);
+
+    public ListKojiArchiveInfoProtobufWrapper() {
+
+    }
+
+    @ProtoFactory
+    public ListKojiArchiveInfoProtobufWrapper(List<KojiArchiveInfo> data) {
+        this.data = data;
+    }
+
+    @ProtoField(1)
+    public List<KojiArchiveInfo> getData() {
+        return data;
+    }
+}

--- a/core/src/main/java/org/jboss/pnc/build/finder/protobuf/ProtobufSerializer.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/protobuf/ProtobufSerializer.java
@@ -20,7 +20,12 @@ import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
 import org.jboss.pnc.build.finder.core.LocalFile;
 
 @AutoProtoSchemaBuilder(
-        includeClasses = { LocalFile.class, MultiValuedMapProtobufWrapper.class },
+        includeClasses = {
+                LocalFile.class,
+                MultiValuedMapProtobufWrapper.class,
+                KojiArchiveInfoAdapter.class,
+                KojiBuildAdapter.class,
+                ListKojiArchiveInfoProtobufWrapper.class },
         schemaFileName = "build-finder.proto",
         schemaFilePath = "proto/",
         schemaPackageName = "org.jboss.pnc.build.finder")


### PR DESCRIPTION
This commit adds support for Protobuf serialization to Infinispan.

The change to use Protobuf is motivated by:

1. JBoss marshalling is deprecated in Infinispan
2. Use of Protobuf is required to use Infinispan remote servers

Implementation
--------------

`KojiBuild` and `KojiArchiveInfo` have Protobuf adapters that marshall
the objects into JSON and vice-versa. Their specific serializer code is
removed as a result.

`ListKojiArchiveInfoProtobufWrapper` object is created to wrap around a
list of `KojiArchiveInfo` objects. This is done to workaround an
Infinispan bug (https://issues.redhat.com/browse/IPROTO-219)

Finally, the configuration for the global cache removes the use of the
specific serializers for `LocalFile` and `KojiBuild` and are instead
replaced by the `ProtobufSerializerImpl` which contains the Protobuf
definitions.

Benchmark results
-----------------

The results also depend on the Koji server response and shouldn't be
taken too seriously. An outlier would indicate serializing might take
more time. From the results, they look pretty similar.

|Without cache: JBoss Marshall|Without cache: Protobuf + JSON|
|----------------------------:|-----------------------------:|
|11m24s|3m38s|
|3m33s|4m30s|
|5m14s|7m06s|

This tests how fast we can retrieve data from Infinispan and marshall
them to a Java Object. From the results, both JBoss Marshalling and
Protobuf+JSON take about the same time

|With cache: JBoss Marshall|With cache: Protobuf + JSON|
|----------------------------:|-----------------------------:|
|5.7s|4.9s|
|4.9s|4.8s|
|4.8s|4.8s|

The benchmark results indicate that JBoss Marshalling takes about the
same time as using Protobuf to marshall and unmarshall data from
Infinispan