### PR TITLE
Remove jboss-marshalling dependency

### DIFF
--- a/build-finder/pom.xml
+++ b/build-finder/pom.xml
@@ -104,12 +104,6 @@
                   </includes>
                 </filter>
                 <filter>
-                  <artifact>org.infinispan:infinispan-jboss-marshalling</artifact>
-                  <includes>
-                    <include>**</include>
-                  </includes>
-                </filter>
-                <filter>
                   <artifact>org.infinispan.protostream:protostream</artifact>
                   <includes>
                     <include>**</include>
@@ -117,12 +111,6 @@
                 </filter>
                 <filter>
                   <artifact>org.jboss.logging:jboss-logging</artifact>
-                  <includes>
-                    <include>**</include>
-                  </includes>
-                </filter>
-                <filter>
-                  <artifact>org.jboss.marshalling:jboss-marshalling-osgi</artifact>
                   <includes>
                     <include>**</include>
                   </includes>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -95,10 +95,6 @@
       <artifactId>infinispan-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-jboss-marshalling</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>rest-client</artifactId>
     </dependency>


### PR DESCRIPTION
It's not used anymore since we switched to Protobuf