### PR TITLE
[NCL-6344] Add explicit cancel checkpoints

### DIFF
--- a/core/src/main/java/org/jboss/pnc/build/finder/core/CancelException.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/CancelException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.build.finder.core;
+
+/**
+ * Exception to throw when CancelWrapper has been set to true. It signifies we got the cancel signal and we should stop
+ * everything
+ */
+public class CancelException extends RuntimeException {
+
+}

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/CancelWrapper.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/CancelWrapper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.build.finder.core;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Wrapper object that will let code know whether it is cancelled and stop running. Object uses AtomicBoolean and is
+ * therefore Thread safe.
+ *
+ * It is very similar to the idea of the interrupt signal for a thread when a future / thread is cancelled. However, the
+ * interrupt signal doesn't work for CompletableFutures, only Futures.
+ */
+public class CancelWrapper {
+
+    private AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    /**
+     * Set cancel "signal" to true.
+     */
+    public void cancel() {
+        this.cancelled.set(true);
+    }
+
+    /**
+     * Check whether the cancel "signal" is set to true.
+     *
+     * @return whether it is cancelled
+     */
+    public boolean isCancelled() {
+        return cancelled.get();
+    }
+
+    /**
+     * Checks if cancel is set to true. If yes, throw a new CancelException to stop everything
+     */
+    public void checkIfWeNeedToStop() {
+
+        if (cancelled.get()) {
+            throw new CancelException();
+        }
+    }
+}


### PR DESCRIPTION
This commit adds cancel support for BuildFinder and
DistributionAnalyzer. They are both Callables and are typically run
inside a threadpool.

While we could use `future.cancel(true)` to force the callable to stop,
it just sends the interrupt signal to the thread running the callable
and it's up to the callable to check whether the thread is interrupted,
and stop.

This commit attempts to do something similar to the interrupt signal
with the `CancelWrapper`. It is a simple wrapper around an AtomicBoolean
that is set to true if we want to cancel/stop everything. It is passed
to the callable via:

```java
// user specifies the cancel wrapper object
buildFinder.setCancelWrapper(cancelWrapper);

...

buildFinder.call();
```

At various checkpoints in the 2 callables, we do an explicit check to
see if the cancelWrapper is true. If true, we stop and throw a
`CancelException`, which is just a `RuntimeException`.

We prefer to use the `CancelWrapper` instead of the Interrupt signal
because the latter is not sent when we try to cancel a
`CompletableFuture`.