### PR TITLE
NCL-9035: Check for invalid license URLs

### DIFF
--- a/core/src/main/java/org/jboss/pnc/build/finder/core/LicenseUtils.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/LicenseUtils.java
@@ -58,6 +58,8 @@ public final class LicenseUtils {
 
     private static final String URL_MARKER = ":/";
 
+    private static final String UNINTERPOLATED_PROPERTY_MARKER = "${";
+
     private static final String DOT = ".";
 
     private static final List<String> TEXT_EXTENSIONS = List.of(".html", ".md", ".php", ".txt");
@@ -104,7 +106,8 @@ public final class LicenseUtils {
      */
     public static boolean isUrl(String... strings) {
         for (String s : strings) {
-            if (s == null || !s.contains(URL_MARKER) || StringUtils.containsWhitespace(s)) {
+            if (!StringUtils.contains(s, URL_MARKER) || StringUtils.containsWhitespace(s)
+                    || StringUtils.contains(s, UNINTERPOLATED_PROPERTY_MARKER)) {
                 return false;
             }
         }

--- a/core/src/main/java/org/jboss/pnc/build/finder/core/SpdxLicenseUtils.java
+++ b/core/src/main/java/org/jboss/pnc/build/finder/core/SpdxLicenseUtils.java
@@ -311,14 +311,18 @@ public final class SpdxLicenseUtils {
     }
 
     static Optional<String> findMatchingLicenseSeeAlso(String licenseUrl) {
-        if (licenseUrl == null || licenseUrl.isBlank()) {
+        if (!LicenseUtils.isUrl(licenseUrl)) {
             return Optional.empty();
         }
 
         Collection<ListedLicense> values = LICENSE_IDS_MAP.values();
 
         for (ListedLicense listedLicense : values) {
-            List<String> seeAlso = listedLicense.getSeeAlsos().stream().map(LicenseUtils::normalizeLicenseUrl).toList();
+            List<String> seeAlso = listedLicense.getSeeAlsos()
+                    .stream()
+                    .filter(LicenseUtils::isUrl)
+                    .map(LicenseUtils::normalizeLicenseUrl)
+                    .toList();
 
             if (seeAlso.contains(LicenseUtils.normalizeLicenseUrl(licenseUrl))) {
                 return Optional.of(getCurrentLicenseId(listedLicense.getId()));

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/LicenseUtilsTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/LicenseUtilsTest.java
@@ -47,7 +47,7 @@ class LicenseUtilsTest {
     }
 
     @Test
-    void tesContainsWordsInSameOrder() {
+    void testContainsWordsInSameOrder() {
         String name = "Apache License, Version 2.0";
         String id = "Apache-2.0";
         assertThat(LicenseUtils.containsWordsInSameOrder(name, id)).isTrue();
@@ -70,7 +70,7 @@ class LicenseUtilsTest {
 
     @ParameterizedTest
     @MethodSource("stringListStringProvider")
-    void tesContainsWordsInSameOrderUrl1(String licenseUrl, List<String> tokens, String licenseId) {
+    void testContainsWordsInSameOrderUrl1(String licenseUrl, List<String> tokens, String licenseId) {
         List<String> tokens1 = LicenseUtils.tokenizeLicenseString(licenseUrl);
         assertThat(tokens1).containsAll(tokens);
         assertThat(LicenseUtils.containsWordsInSameOrder(licenseUrl, licenseId)).isTrue();

--- a/core/src/test/java/org/jboss/pnc/build/finder/core/SpdxLicenseUtilsTest.java
+++ b/core/src/test/java/org/jboss/pnc/build/finder/core/SpdxLicenseUtilsTest.java
@@ -105,6 +105,8 @@ class SpdxLicenseUtilsTest {
                 .hasValue("Apache-2.0");
         assertThat(SpdxLicenseUtils.findMatchingLicenseSeeAlso("https://apache.org/licenses/LICENSE-2.0.html"))
                 .hasValue("Apache-2.0");
+        assertThat(SpdxLicenseUtils.findMatchingLicenseSeeAlso("${project.scm.url}/raw-file/tip/LICENSE"))
+                .isEmpty();
     }
 
     @Test


### PR DESCRIPTION
`LicenseUtils::isUrl` now checks for uninterpolated Maven properties when determining if a given URL is valid.

`SpdxLicenseUtils::findMatchingLicense` now calls `LicenseUtils::isUrl` to filter out invalid URLs.