### PR TITLE
Skip signing tag for maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1331,6 +1331,7 @@ junit.jupiter.execution.parallel.config.dynamic.factor=1</configurationParameter
           <tagNameFormat>@{project.version}</tagNameFormat>
           <autoVersionSubmodules>true</autoVersionSubmodules>
           <releaseProfiles>empty-javadoc-jar,gpg-sign</releaseProfiles>
+          <signTag>false</signTag>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
The default for jboss-parent-50 is to sign tags created by maven-release-plugin with the gpg key. Unfortunately, the gpg passphrase is not passed through correctly to git and fails.

This setting just tells maven-release-plugin to not sign the tag with the gpg key.